### PR TITLE
Add payment popup to coin purchase

### DIFF
--- a/app/buycoins/page.tsx
+++ b/app/buycoins/page.tsx
@@ -6,12 +6,15 @@ import { motion } from "framer-motion";
 import { Listbox } from "@headlessui/react";
 import clsx from "clsx";
 import { CoinCard } from "@/components/CoinCard";
+import PaymentPopup from "@/components/PaymentPopup";
 import { useTidio } from "@/lib/useTidio";
 
 export default function BuyCoinsPage() {
   const [currency, setCurrency] =
     useState<"USD" | "EUR" | "CAD" | "AUD">("USD");
   const { openChatWithMessage } = useTidio();
+  const [showPaymentPopup, setShowPaymentPopup] = useState(false);
+  const [pendingMessage, setPendingMessage] = useState("");
 
   const priceData = {
     USD: [
@@ -136,12 +139,12 @@ export default function BuyCoinsPage() {
                   value={coin.value}
                   index={i}
                   onBuy={() => {
-                    const message = `Hello! I want to purchase:\n\n- ${coin.amount.toLocaleString()} coins\n- Price: ${coin.value}`;
-                    openChatWithMessage(message);
-                    window.scrollTo({
-                      top: document.body.scrollHeight,
-                      behavior: "smooth",
-                    });
+                    const message =
+                      `Coin purchase request:\n\n` +
+                      `Amount: ${coin.amount.toLocaleString()} coins\n` +
+                      `Price: ${coin.value}`;
+                    setPendingMessage(message);
+                    setShowPaymentPopup(true);
                   }}
                 />
               </motion.div>
@@ -206,5 +209,14 @@ export default function BuyCoinsPage() {
         </motion.div>
       </div>
     </main>
+    <PaymentPopup
+      show={showPaymentPopup}
+      onClose={() => setShowPaymentPopup(false)}
+      onSelect={(method) => {
+        openChatWithMessage(pendingMessage + `\nPayment Method: ${method}`);
+        setShowPaymentPopup(false);
+        window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+      }}
+    />
   );
 }

--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -8,7 +8,6 @@ import { useAuth } from "@/context/AuthContext";
 import { Listbox } from "@headlessui/react";
 import clsx from "clsx";
 import { useTidio } from "@/lib/useTidio";
-import PaymentPopup from "@/components/PaymentPopup";
 
 
 
@@ -37,9 +36,6 @@ export default function GameDetailPage() {
   };
 
   const { openChatWithMessage } = useTidio();
-
-  const [showPaymentPopup, setShowPaymentPopup] = useState(false);
-  const [pendingMessage, setPendingMessage] = useState("");
 
 
   const universalPacks = [
@@ -395,7 +391,8 @@ export default function GameDetailPage() {
     }
 
     // Ako sve prolazi, nastavi
-    const message = `New purchase request:\n\n` +
+    const message =
+      `New purchase request:\n\n` +
       `Game: ${game.name}\n` +
       `Pack: ${universalPacks[selectedPackIndex].coins} coins\n` +
       `Quantity: ${quantity}\n` +
@@ -404,8 +401,8 @@ export default function GameDetailPage() {
       `Country: ${countryLabel(selectedCountry)}\n` +
       `Screenshot: Please send the screenshot in this chat.`;
 
-    setPendingMessage(message);
-    setShowPaymentPopup(true);
+    openChatWithMessage(message);
+    window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
   }}
 
 
@@ -455,15 +452,6 @@ export default function GameDetailPage() {
 </section>
 
     </main>
-    <PaymentPopup
-      show={showPaymentPopup}
-      onClose={() => setShowPaymentPopup(false)}
-      onSelect={(method) => {
-        openChatWithMessage(pendingMessage + `\nPayment Method: ${method}`);
-        setShowPaymentPopup(false);
-        window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
-      }}
-    />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- trigger payment method selection when buying coins
- send the game purchase message directly to Tidio

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c2c4e4cac8321a0baafffa7ac06c2